### PR TITLE
Policy Studio 7.7.0 20210830+ compatible custom filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,16 +11,31 @@ repositories {
     mavenCentral()
 }
 
-
+def apim_folder = '/Users/cwilliams/Downloads/APIGateway_7.7.20210830_Core_linux-x86-64_BN02/content/system'
+def ps_folder = '/Users/cwilliams/SharedFolder/apim'
 
 dependencies {
-    compile fileTree(dir: '/Users/rnatarajan/AxwayProducts/apim_7_7_mar2021/lib', include: '*.jar')
-    compile fileTree(dir: '/Users/rnatarajan/AxwayProducts/apim_7_7_mar2021/lib/modules', include: '*.jar')
-    compile fileTree(dir: '/Users/rnatarajan/AxwayProducts/apim_7_7_mar2021/lib/plugins', include: '*.jar')
+    compile fileTree(dir: "${apim_folder}/lib", include: '*.jar')
+    compile fileTree(dir: "${apim_folder}/lib/modules", include: '*.jar')
+    compile fileTree(dir: "${apim_folder}/lib/plugins", include: '*.jar')
 
     // policystudio
-    compile fileTree(dir: '/Users/rnatarajan/AxwayProducts/apim_7_7_mar2021/plugins', include: '*.jar')
+    compile fileTree(dir: "${ps_folder}/plugins", include: '*.jar')
 
-    compile files("/Users/rnatarajan/AxwayProducts/apim_7_7_mar2021/plugins/com.vordel.rcp.filterbase_7.7.0.v20210414-1740")
+    compile files("${ps_folder}/plugins/com.vordel.rcp.filterbase_7.7.0.v20211004-1323")
 
+}
+
+jar {
+    manifest {
+        attributes('Bundle-Name': 'Circuit Loop Filter',
+                   'Bundle-SymbolicName': 'rslr.circuit.loop;singleton:=true',
+                   'Bundle-Version': '2.0.0',
+                   'Bundle-Vendor': 'Axway, Inc.',
+                   'Bundle-ClassPath': '.',
+                   'Export-Package': 'rslr.circuit.loop',
+                   'Bundle-RequiredExecutionEnvironment': 'JavaSE-1.7',
+                   'Bundle-ManifestVersion': '2',
+                   'Require-Bundle': 'com.vordel.rcp.filterbase')
+    }
 }

--- a/src/main/java/rslr/circuit/loop/CircuitLoopFilter.java
+++ b/src/main/java/rslr/circuit/loop/CircuitLoopFilter.java
@@ -5,7 +5,6 @@ import java.util.Set;
 
 import com.vordel.circuit.DefaultFilter;
 import com.vordel.circuit.DelegatingFilter;
-import com.vordel.circuit.FilterContainerImpl;
 import com.vordel.circuit.GlobalProperties;
 import com.vordel.circuit.MessageProcessor;
 import com.vordel.config.ConfigContext;
@@ -18,12 +17,6 @@ public class CircuitLoopFilter extends DefaultFilter implements DelegatingFilter
 	@Override
 	public Class<? extends MessageProcessor> getMessageProcessorClass() throws ClassNotFoundException {
 		return CircuitLoopProcessor.class;
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public Class<? extends FilterContainerImpl> getConfigPanelClass() throws ClassNotFoundException {
-		return (Class<? extends FilterContainerImpl>) Class.forName("rslr.circuit.loop.CircuitLoopGUIFilter");
 	}
 
 	private ESPK loopCircuitPK = EntityStore.ES_NULL_PK;

--- a/src/main/java/rslr/circuit/loop/CircuitLoopFilterPage.java
+++ b/src/main/java/rslr/circuit/loop/CircuitLoopFilterPage.java
@@ -8,8 +8,8 @@ public class CircuitLoopFilterPage extends VordelPage {
 	public CircuitLoopFilterPage() {
 		super("circuitloopPage");
 
-		setTitle(resolve("CIRCUITLOOP_PAGE"));
-		setDescription(resolve("CIRCUITLOOP_PAGE_DESCRIPTION"));
+		setTitle(Resources.CIRCUITLOOP_PAGE);
+		setDescription(Resources.CIRCUITLOOP_PAGE_DESCRIPTION);
 		setPageComplete(false);
 	}
 

--- a/src/main/java/rslr/circuit/loop/CircuitLoopGUIFilter.java
+++ b/src/main/java/rslr/circuit/loop/CircuitLoopGUIFilter.java
@@ -9,7 +9,6 @@ import com.vordel.client.manager.Manager;
 import com.vordel.client.manager.ManagerEntityStore;
 import com.vordel.client.manager.filter.DefaultGUIFilter;
 import com.vordel.client.manager.filter.DelegatingFilterSynchronizer;
-import com.vordel.client.manager.wizard.VordelPage;
 import com.vordel.common.util.PropDef;
 import com.vordel.config.ConfigContext;
 import com.vordel.es.ESPK;
@@ -19,7 +18,6 @@ import com.vordel.es.EntityStoreException;
 import com.vordel.trace.Trace;
 
 import java.util.Set;
-import java.util.Vector;
 
 public class CircuitLoopGUIFilter extends DefaultGUIFilter implements ICircuitDelegate {
 	public static final String ERR_PARENTPOINTER = "Configuration error the circuit loop '%s' is pointing to it's parent circuit";
@@ -79,21 +77,6 @@ public class CircuitLoopGUIFilter extends DefaultGUIFilter implements ICircuitDe
 
 	private void setLoopCircuit(Circuit loopCircuit) {
 		this.loopCircuit = loopCircuit;
-	}
-
-	@Override
-	public Vector<VordelPage> getPropertyPages() {
-		Vector<VordelPage> pages = new Vector<>();
-
-		pages.add(new CircuitLoopFilterPage());
-		pages.add(createLogPage());
-
-		return pages;
-	}
-
-	@Override
-	public String[] getCategories() {
-		return new String[] { ("FILTER_GROUP_CIRCUIT") };
 	}
 
 	@Override

--- a/src/main/java/rslr/circuit/loop/Resources.java
+++ b/src/main/java/rslr/circuit/loop/Resources.java
@@ -1,0 +1,20 @@
+package rslr.circuit.loop;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Resources extends NLS {
+
+    private static final String BUNDLE_NAME = "rslr.circuit.loop.resources"; //$NON-NLS-1$
+
+    public static String CIRCUITLOOP_PAGE;
+    public static String CIRCUITLOOP_PAGE_DESCRIPTION;
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Resources.class);
+    }
+
+    private Resources() {
+        super();
+    }
+}

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         id="com.vordel.rcp.filterbase.filterGUI.loop"
+         point="com.vordel.rcp.filterbase.filterGUI">
+      <filter
+            class="rslr.circuit.loop.CircuitLoopFilter"
+            icon="filter_small"
+            name="Circuit Loop"
+            page="rslr.circuit.loop.CircuitLoopFilterPage">
+         <category
+               id="com.vordel.ui.filter.category.utility" />
+      </filter>
+   </extension>
+   <extension
+         point="com.vordel.rcp.filterbase.filterModel">
+      <filter
+            class="rslr.circuit.loop.CircuitLoopGUIFilter"
+            type="rslr.circuit.loop.CircuitLoopFilter">
+      </filter>
+   </extension>
+</plugin>


### PR DESCRIPTION
These changes migrate the circuit loop filter to:
- build with an OSGI/Eclipse-compatible `META-INF/MANIFEST.MF`
- Use the new eclipse extension for registering the filter's UI and model representations within Policy Studio
- Use Eclipse' builtin NLS mechanism for i18n strings (which allows build-time checking of typos in i18n keys)

This requires PS 7.7 20210830 or later, which is when the new extension was introduced.

The upshot here is that you can copy the generated jar into Policy Studio's `dropins` folder - rather than use the **Window > Preferences > Runtime Dependencies** preference page and have to restart with `-clean`. The jar/pluign gets picked on on next start/restart of PS.

Not done, but easy to add:
- externalize the UI strings for the filter name, plugin name/vendor to use i18n so they can be translated
- change the default icon to one bundled as a png in the jar

Possible other extensions:
- Add an eclipse extension to point to the entity type xml file(s) bundled in the JAR so we can skip (or modify) the **File > Import Custom Filter** step.